### PR TITLE
Conform to validation failure format

### DIFF
--- a/lib/conduit/support/middleware/uniqueness.ex
+++ b/lib/conduit/support/middleware/uniqueness.ex
@@ -39,7 +39,7 @@ defmodule Conduit.Support.Middleware.Uniqueness do
 
       case Unique.claim(unique_field, owner, value) do
         :ok -> {:cont, :ok}
-        {:error, :already_taken} -> {:halt, {:error, Map.new([{unique_field, error_message}])}}
+        {:error, :already_taken} -> {:halt, {:error, Map.new([{unique_field, [error_message]}])}}
       end
     end)
   end

--- a/lib/conduit/support/middleware/uniqueness.ex
+++ b/lib/conduit/support/middleware/uniqueness.ex
@@ -39,7 +39,7 @@ defmodule Conduit.Support.Middleware.Uniqueness do
 
       case Unique.claim(unique_field, owner, value) do
         :ok -> {:cont, :ok}
-        {:error, :already_taken} -> {:halt, {:error, Keyword.new([{unique_field, error_message}])}}
+        {:error, :already_taken} -> {:halt, {:error, Map.new([{unique_field, error_message}])}}
       end
     end)
   end

--- a/test/conduit/accounts/accounts_test.exs
+++ b/test/conduit/accounts/accounts_test.exs
@@ -31,9 +31,16 @@ defmodule Conduit.AccountsTest do
 
     @tag :integration
     test "should fail when registering identical username at same time and return error" do
-      1..2
-      |> Enum.map(fn x -> Task.async(fn -> Accounts.register_user(build(:user, email: "jake#{x}@jake.jake")) end) end)
-      |> Enum.map(&Task.await/1)
+      [success, failure] =
+        1..2
+        |> Enum.map(fn x -> Task.async(fn -> Accounts.register_user(build(:user, email: "jake#{x}@jake.jake")) end) end)
+        |> Enum.map(&Task.await/1)
+        |> Enum.sort()
+
+      assert {:ok, %User{}} = success
+      assert {:error, :validation_failure, errors} = failure
+
+      assert errors == %{username: ["has already been taken"]}
     end
 
     @tag :integration
@@ -60,9 +67,16 @@ defmodule Conduit.AccountsTest do
 
     @tag :integration
     test "should fail when registering identical email addresses at same time and return error" do
-      1..2
-      |> Enum.map(fn x -> Task.async(fn -> Accounts.register_user(build(:user, username: "user#{x}")) end) end)
-      |> Enum.map(&Task.await/1)
+      [success, failure] =
+        1..2
+        |> Enum.map(fn x -> Task.async(fn -> Accounts.register_user(build(:user, username: "user#{x}")) end) end)
+        |> Enum.map(&Task.await/1)
+        |> Enum.sort()
+
+      assert {:ok, %User{}} = success
+      assert {:error, :validation_failure, errors} = failure
+
+      assert errors == %{email: ["has already been taken"]}
     end
 
     @tag :integration

--- a/test/conduit/accounts/accounts_test.exs
+++ b/test/conduit/accounts/accounts_test.exs
@@ -32,7 +32,7 @@ defmodule Conduit.AccountsTest do
     @tag :integration
     test "should fail when registering identical username at same time and return error" do
       1..2
-      |> Enum.map(fn x -> Task.async(fn -> Accounts.register_user(build(:user, email: "jake#{x}@jake.jake")) end)  end)
+      |> Enum.map(fn x -> Task.async(fn -> Accounts.register_user(build(:user, email: "jake#{x}@jake.jake")) end) end)
       |> Enum.map(&Task.await/1)
     end
 
@@ -61,7 +61,7 @@ defmodule Conduit.AccountsTest do
     @tag :integration
     test "should fail when registering identical email addresses at same time and return error" do
       1..2
-      |> Enum.map(fn x -> Task.async(fn -> Accounts.register_user(build(:user, username: "user#{x}")) end)  end)
+      |> Enum.map(fn x -> Task.async(fn -> Accounts.register_user(build(:user, username: "user#{x}")) end) end)
       |> Enum.map(&Task.await/1)
     end
 


### PR DESCRIPTION
The uniqueness middleware produces validation failure errors in a different format than other validations.

This was uncaught as the concurrency test cases didn't have any assertions.

4a4a1172590e009a3f644dc94a70cbe3472223e4 demonstrates the failure. It interestingly only shows a single failure which I suspect is because the actual validations prevented the other test's duplicate registration attempt.