### PR TITLE
Use appropriate key for configuring cost

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -30,4 +30,4 @@ config :conduit, Conduit.Repo,
   hostname: "localhost",
   pool_size: 1
 
-config :comeonin, :bcrypt_log_rounds, 4
+config :bcrypt_elixir, :log_rounds, 4


### PR DESCRIPTION
The key changed when BCrypt got extracted to a separate dependency in https://github.com/riverrun/comeonin/commit/bd39137c0b4613e3b14fc654c577cc637313549f

Using the appropriate key improves the performance of test runs significantly.

**Before**

    % mix test --seed 0
    ...
    Finished in 28.8 seconds
    65 tests, 0 failures
    
    Randomized with seed 0

**After**

    % mix test --seed 0
    ...
    Finished in 19.0 seconds
    65 tests, 0 failures
    
    Randomized with seed 0