### PR TITLE
Use runtime configuration when resetting storage

### DIFF
--- a/test/support/storage.ex
+++ b/test/support/storage.ex
@@ -21,9 +21,7 @@ defmodule Conduit.Storage do
   end
 
   defp reset_readstore! do
-    readstore_config = Application.get_env(:conduit, Conduit.Repo)
-
-    {:ok, conn} = Postgrex.start_link(readstore_config)
+    {:ok, conn} = Postgrex.start_link(Conduit.Repo.config())
 
     Postgrex.query!(conn, truncate_readstore_tables(), [])
   end


### PR DESCRIPTION
When `Repo` is initialized with the `url` property instead of user/pass/hostname/database fields, it fails to reset storage.
This loads the runtime configuration and passes it to `Postgrex`.