### PR TITLE
Add UncommitedChanges module

### DIFF
--- a/lib/conduit/commanded/uncommitted_changes.ex
+++ b/lib/conduit/commanded/uncommitted_changes.ex
@@ -1,0 +1,23 @@
+defmodule Conduit.Commanded.UncommittedChanges do
+  defstruct [:events]
+
+  def new do
+    %__MODULE__{events: []}
+  end
+
+  def append_events(changes, []) do
+    changes
+  end
+
+  def append_events(changes, events) do
+    Map.put(changes, :events, changes.events ++ events)
+  end
+
+  def append_event(changes, event) do
+    Map.put(changes, :events, changes.events ++ [event])
+  end
+
+  def get_events(changes) do
+    changes.events
+  end
+end


### PR DESCRIPTION
I added some module that allows us to have a more declarative API to deal with these type of function chaining that may add some events before returning.

@slashdotdash I would love to see this module in Commanded itself since currently there is no clean solution to deal with the situation when you have multiple functions behind one `execute` handler.

What do you think?